### PR TITLE
Switch to HookHandlers system

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <ruleset>
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamName" />

--- a/extension.json
+++ b/extension.json
@@ -9,9 +9,11 @@
 	"descriptionmsg": "qrlite-desc",
 	"license-name": "GPL-3.0-or-later",
 	"type": "other",
-	"AutoloadClasses": {
-		"QRLiteHooks": "QRLite.hooks.php",
-		"QRLiteFunctions": "QRLite.functions.php"
+	"requires": {
+		"MediaWiki": ">= 1.35"
+	},
+	"AutoloadNamespaces": {
+		"MediaWiki\\Extension\\QRLite\\": "./src/"
 	},
 	"ExtensionMessagesFiles": {
 		"QRLiteMagic": "QRLite.i18n.magic.php"
@@ -22,9 +24,12 @@
 		]
 	},
 	"Hooks": {
-		"ParserFirstCallInit": [
-			"QRLiteHooks::onParserFirstCallInit"
-		]
+		"ParserFirstCallInit": "QRLite"
+	},
+	"HookHandlers": {
+		"QRLite": {
+			"class": "MediaWiki\\Extension\\QRLite\\QRLiteHooks"
+		}
 	},
 	"load_composer_autoloader": true,
 	"manifest_version": 1

--- a/src/QRLiteFunctions.php
+++ b/src/QRLiteFunctions.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace MediaWiki\Extension\QRLite;
+
 use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelHigh;
 use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
 use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
@@ -7,6 +9,8 @@ use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelQuartile;
 use Endroid\QrCode\QrCode;
 use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Writer\SvgWriter;
+use Exception;
+use Html;
 
 /**
  * The actual QRLite Functions

--- a/src/QRLiteHooks.php
+++ b/src/QRLiteHooks.php
@@ -1,21 +1,25 @@
 <?php
 
+namespace MediaWiki\Extension\QRLite;
+
+use MediaWiki\Hook\ParserFirstCallInitHook;
+
 /**
  * Hooks for QRLite extension
  *
  * @file
  * @ingroup Extensions
  */
-class QRLiteHooks {
+class QRLiteHooks implements ParserFirstCallInitHook {
 
 	/**
 	 * Register parser hooks
 	 *
 	 * See also http://www.mediawiki.org/wiki/Manual:Parser_functions
 	 */
-	public static function onParserFirstCallInit( &$parser ) {
+	public function onParserFirstCallInit( $parser ) {
 		// Register parser functions
-		$parser->setFunctionHook( 'qrlite', 'QRLiteHooks::qrliteFunctionHook' );
+		$parser->setFunctionHook( 'qrlite', [ $this, 'qrliteFunctionHook' ] );
 
 		return true;
 	}


### PR DESCRIPTION
This moves the PHP classes to their own directory, and switches to using the new HookHandlers system for using hooks.