### PR TITLE
Add load_composer_autoloader to extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -26,5 +26,6 @@
       "QRLiteHooks::onParserFirstCallInit"
     ]
   },
+  "load_composer_autoloader": true,
   "manifest_version": 1
 }


### PR DESCRIPTION
This makes it possible to load dependencies from the extension's vendor directory and not just from the one at the site root.

Bug: #9