### PR TITLE
Remove 'static' from class methods, update phpcs, and fix var name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "1.3.2",
-		"mediawiki/mediawiki-codesniffer": "40.0.1",
+		"mediawiki/mediawiki-codesniffer": "41.0.0",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"mediawiki/minus-x": "1.1.1"
 	},

--- a/src/QRLiteHooks.php
+++ b/src/QRLiteHooks.php
@@ -35,9 +35,9 @@ class QRLiteHooks implements ParserFirstCallInitHook {
 	 *
 	 * @return array
 	 */
-	public static function qrliteFunctionHook( $parser, $main ) {
+	public function qrliteFunctionHook( $parser, $main ) {
 		$args = array_slice( func_get_args(), 2 );
-		$params = self::extractOptions( $args );
+		$params = $this->extractOptions( $args );
 
 		// If the prefix is not set as key-value, but the first parameter is set
 		// Use it as prefix (short form)
@@ -45,9 +45,9 @@ class QRLiteHooks implements ParserFirstCallInitHook {
 			$params['prefix'] = $main;
 		}
 
-		$id = QRLiteFunctions::generateQRCode( $params );
+		$html = QRLiteFunctions::generateQRCode( $params );
 
-		return [ $id, 'noparse' => true, 'isHTML' => true ];
+		return [ $html, 'noparse' => true, 'isHTML' => true ];
 	}
 
 	/**
@@ -57,7 +57,7 @@ class QRLiteHooks implements ParserFirstCallInitHook {
 	 * @param array $options
 	 * @return array $results
 	 */
-	private static function extractOptions( array $options ) {
+	private function extractOptions( array $options ) {
 		$results = [];
 
 		foreach ( $options as $option ) {


### PR DESCRIPTION
No need for these methods to be static as they're now called from a class instance only. Update the mediawiki-codesniffer version, although there's no changes resulting from that. And update a variable name to make it clearer what it holds.