### PR TITLE
Port to endroid/qr-code 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"require": {
 		"composer/installers": ">=1.0.1",
-		"endroid/qr-code": "^4.6"
+		"endroid/qr-code": "^6.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",

--- a/src/QRLiteFunctions.php
+++ b/src/QRLiteFunctions.php
@@ -2,10 +2,8 @@
 
 namespace MediaWiki\Extension\QRLite;
 
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelHigh;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelQuartile;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\QrCode;
 use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Writer\SvgWriter;
@@ -43,30 +41,22 @@ class QRLiteFunctions {
 
 		$ecc = (int)self::paramGet( $params, 'ecc', 2 );
 
-		// TODO: Doesn't seem to work
-		$eccLevel = new ErrorCorrectionLevelMedium();
-		if ( $ecc === 1 ) {
-			$eccLevel = new ErrorCorrectionLevelLow();
-		} else {
-			if ( $ecc === 2 ) {
-				$eccLevel = new ErrorCorrectionLevelMedium();
-			} else {
-				if ( $ecc === 3 ) {
-					$eccLevel = new ErrorCorrectionLevelQuartile();
-				} else {
-					if ( $ecc === 4 ) {
-						$eccLevel = new ErrorCorrectionLevelHigh();
-					}
-				}
-			}
-		}
+		$eccLevel = match ( $ecc ) {
+			1 => ErrorCorrectionLevel::Low,
+			3 => ErrorCorrectionLevel::Quartile,
+			4 => ErrorCorrectionLevel::High,
+			default => ErrorCorrectionLevel::Medium,
+		};
 
 		$image = '';
 		try {
-			$qrCode = new QrCode( $content );
-			$qrCode->setSize( $size * 30 );
-			$qrCode->setMargin( $margin );
-			$qrCode->setErrorCorrectionLevel( $eccLevel );
+			$qrCode = new QrCode(
+				data: $content,
+				encoding: new Encoding( 'UTF-8' ),
+				errorCorrectionLevel: $eccLevel,
+				size: (int)$size * 30,
+				margin: (int)$margin,
+			);
 			$writer = $format === 'svg' ? new SvgWriter() : new PngWriter();
 			$writerOptions = [
 				SvgWriter::WRITER_OPTION_EXCLUDE_XML_DECLARATION => true


### PR DESCRIPTION
endroid/qr-code 4.x ships the same Endroid\QrCode\ PSR-4 namespace as 6.x, so when QRLite is installed alongside any extension requiring 6.x (e.g. OATHAuth on MediaWiki 1.45), the last-loaded composer autoloader wins and one side fatals with either:

  - "Unknown named parameter $writer" (6.x caller, 4.x Builder loaded), or
  - "Call to undefined method QrCode::setSize()" (4.x caller, 6.x QrCode loaded — now readonly).

Bump composer require to ^6.0 and rewrite QRLiteFunctions::generateQRCode against the 6.x API (ErrorCorrectionLevel enum, named-parameter QrCode constructor, no setters).

See https://github.com/gesinn-it/QRLite/issues/20